### PR TITLE
Fix CLI docstring

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -1,4 +1,4 @@
-"""FastmMCP CLI tools."""
+"""FastMCP CLI tools."""
 
 import importlib.metadata
 import importlib.util


### PR DESCRIPTION
## Summary
- correct CLI module docstring

## Testing
- `uv sync` *(fails: No route to host)*
- `uv run pre-commit run --all-files` *(fails: No route to host)*
- `uv run pytest` *(fails: No route to host)*